### PR TITLE
Change `maxLPD` parameter handling & enable `trainLPD` calculation with only training data provided (no model)

### DIFF
--- a/R/aoa.R
+++ b/R/aoa.R
@@ -202,7 +202,7 @@ aoa <- function(newdata,
     trainDI <- trainDI(model, train, variables, weight, CVtest, CVtrain, method, useWeight, LPD)
   }
 
-  if (calc_LPD == TRUE && sd(trainDI$weight) != 0) {
+  if (calc_LPD == TRUE) {
     # maxLPD <- trainDI$avrgLPD
     trainDI$maxLPD <- maxLPD
   }

--- a/R/trainDI.R
+++ b/R/trainDI.R
@@ -273,12 +273,24 @@ trainDI <- function(model = NA,
 
     # Average LPD in trainData
     avrgLPD <- round(mean(trainLPD))
+  }
 
-    # Optimal maxLPD ----
-    # if (maxLPD == "opt") {
-    #   maxLPD <- stats::quantile(trainLPD, 0.25,na.rm=TRUE)
-    #   message(paste("maxLPD was set to", maxLPD))
-    # }
+  # calculate trainLPD, avrgLPD and maxLPD
+  if (LPD == TRUE && is.null(CVtest) && is.null(CVtrain)) {
+    trainLPD <- c()
+    for (j in  seq(nrow(train))) {
+
+      trainDistAll   <- .alldistfun(t(train[j,]), train,  method, S_inv=S_inv)[-1]
+
+      DItrainDistAll <- trainDistAll / trainDist_avrgmean
+
+      count <- sum(DItrainDistAll < thres)
+
+      trainLPD <- append(trainLPD, count)
+    }
+
+    # Average LPD in trainData
+    avrgLPD <- round(mean(trainLPD))
   }
 
 
@@ -298,7 +310,7 @@ trainDI <- function(model = NA,
     method = method
   )
 
-  if (LPD == TRUE && !is.null(CVtest) && !is.null(CVtrain)) {
+  if (LPD == TRUE) {
     aoa_results$trainLPD <- trainLPD
     aoa_results$avrgLPD <- avrgLPD
   }

--- a/R/trainDI.R
+++ b/R/trainDI.R
@@ -41,7 +41,6 @@
 #'  \item{threshold}{The DI threshold used for inside/outside AOA}
 #'  \item{trainLPD}{LPD of the training data}
 #'  \item{avrgLPD}{Average LPD of the training data}
-#'  \item{maxLPD}{Maximum neighbors considered for LPD calculation}
 #'
 #'
 #'
@@ -109,8 +108,7 @@ trainDI <- function(model = NA,
                     CVtrain = NULL,
                     method="L2",
                     useWeight = TRUE,
-                    LPD = FALSE,
-                    maxLPD = "opt"){
+                    LPD = FALSE){
 
   # get parameters if they are not provided in function call-----
   if(is.null(train)){train = aoa_get_train(model)}
@@ -277,10 +275,10 @@ trainDI <- function(model = NA,
     avrgLPD <- round(mean(trainLPD))
 
     # Optimal maxLPD ----
-    if (maxLPD == "opt") {
-      maxLPD <- stats::quantile(trainLPD, 0.25,na.rm=TRUE)
-      message(paste("maxLPD was set to", maxLPD))
-    }
+    # if (maxLPD == "opt") {
+    #   maxLPD <- stats::quantile(trainLPD, 0.25,na.rm=TRUE)
+    #   message(paste("maxLPD was set to", maxLPD))
+    # }
   }
 
 
@@ -303,7 +301,6 @@ trainDI <- function(model = NA,
   if (LPD == TRUE && !is.null(CVtest) && !is.null(CVtrain)) {
     aoa_results$trainLPD <- trainLPD
     aoa_results$avrgLPD <- avrgLPD
-    aoa_results$maxLPD <- maxLPD
   }
 
   class(aoa_results) = "trainDI"


### PR DESCRIPTION
`maxLPD`: 
- Previous: The user decided between `max`, `opt` or a a whole number, to specify how many nearest training data points should be used for the LPD calculation
- Now: The user either sets a number from 0 to 1 to use a percentage or a whole number bigger than one to specify the number of nearest training points to be considered for the LPD calculation. Using an optimal `maxLPD` is not possible anymore, as it was found out to be not very meaningfull.

`trainLPD with no model`:
- Previous: It was not possible to calculate the LPD based only on the training data with considering all training points for the threshold derivation when no CV fold are provided.
- Now: If no CV fold are provioded or can be derived from the model, the calculation will now be performed on the distances to all training data points.