### PR TITLE
Add `LPDtoErrormetric` functionality

### DIFF
--- a/R/LPDtoErrormetric.R
+++ b/R/LPDtoErrormetric.R
@@ -228,7 +228,7 @@ get_preds_all <- function(model, trainDI){
   preds_all$LPD <- trainDI$trainLPD[!is.na(trainDI$trainLPD)]
   ## only take predictions from inside the AOA:
   preds_all <-  preds_all[preds_all$LPD>0,]
-  attr(preds_all, "maxLPD") <- trainDI$maxLPD
+  attr(preds_all, "avrgLPD") <- trainDI$avrgLPD
 
   return(preds_all)
 

--- a/R/plot.R
+++ b/R/plot.R
@@ -401,7 +401,7 @@ plot.geodist <- function(x, unit = "m", stat = "density", ...){
 #'
 
 
-plot.errorModel <- function(x, ...){
+plot.errorModelDI <- function(x, ...){
 
   performance = attr(x, "performance")[,c("DI", "metric")]
   performance$what = "cross-validation"
@@ -421,8 +421,30 @@ plot.errorModel <- function(x, ...){
 }
 
 
+#' @name plot
+#' @description Plot the LPD and errormetric from Cross-Validation with the modelled relationship
+#' @param x errorModelLPD, see \code{\link{LPDtoErrormetric}}
+#' @param ... other params
+#' @export
+#' @return a ggplot
+#'
 
 
+plot.errorModelLPD <- function(x, ...){
+
+  performance = attr(x, "performance")[,c("LPD", "metric")]
+  performance$what = "cross-validation"
+
+  model_line = data.frame(LPD = performance$LPD,
+                          metric = predict(x, performance),
+                          what = "model")
 
 
+  p = ggplot()+
+    geom_point(data = performance, mapping = aes_string(x = "LPD", y = "metric", shape = "what"))+
+    geom_line(data = model_line, mapping =  aes_string(x = "LPD", y = "metric", linetype = "what"), lwd = 1)+
+    theme(legend.title = element_blank(), legend.position = "bottom")
 
+  return(p)
+
+}


### PR DESCRIPTION
Added `LPDtoErrormetric` functionality. The function derives a model for the relation between the LPD and the true error in the training data. The derived model can be used to estimate the error over the whole Area of interest.